### PR TITLE
Fix extra minus sign in kinematicMap

### DIFF
--- a/src/rigidbody/RigidBodySystem.cpp
+++ b/src/rigidbody/RigidBodySystem.cpp
@@ -20,7 +20,7 @@ namespace
             -q.x() * omega.x() - q.y() * omega.y() - q.z() * omega.z(),
             q.w() * omega.x() + q.z() * omega.y() - q.y() * omega.z(),
             -q.z() * omega.x() + q.w() * omega.y() + q.x() * omega.z(),
-            -q.y() * omega.x() - q.x() * omega.y() + q.w() * omega.z()
+            q.y() * omega.x() - q.x() * omega.y() + q.w() * omega.z()
         );
     }
 }


### PR DESCRIPTION
## Description
In line 23 of the file `rigidbody/RigidBodySystem.cpp`, there was an extra minus sign, which caused incorrect results in the calculation.

## Fix
Removed the extra minus sign to align the implementation with expression of `H` in [course notes (Page 161)](https://siggraphcontact.github.io/assets/files/SIGGRAPH22_friction_contact_notes.pdf).

